### PR TITLE
fix spdlog cannot format an argument

### DIFF
--- a/HorizonEngine/src/HorizonEngine/App.cpp
+++ b/HorizonEngine/src/HorizonEngine/App.cpp
@@ -45,7 +45,7 @@ namespace Hzn
 		// different function that might need to handle such event
 		EventDispatcher dispatcher(e);
 		dispatcher.Dispatch<WindowCloseEvent>(std::bind(&App::onWindowClose, this, std::placeholders::_1));
-		HZN_CORE_TRACE(e.ToString());
+		HZN_CORE_TRACE(e);
 
 		//! update the added layers in the application, in reverse order.
 		//! this means we would go through all the overlays and then the layers.

--- a/HorizonEngine/src/HorizonEngine/Events/Event.h
+++ b/HorizonEngine/src/HorizonEngine/Events/Event.h
@@ -11,10 +11,12 @@ https://github.com/dquist/EventBus
 */
 
 #include "HorizonEngine/Core/Core.h"
+#include "fmt/ostream.h"
 
 #define BIT(x) (1 << (x))
 
 namespace Hzn {
+
 
 	enum class HZN_API TypeOfEvent
 	{
@@ -95,4 +97,7 @@ namespace Hzn {
 	}
 
 }
+
+template<>
+struct fmt::formatter<Hzn::Event> : fmt::ostream_formatter {};
 #endif // !HZN_APPLICATION_EVENT_H

--- a/HorizonEngine/src/HorizonEngine/Logging/Logging.h
+++ b/HorizonEngine/src/HorizonEngine/Logging/Logging.h
@@ -8,6 +8,7 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/fmt/fmt.h"
+#include "fmt/ostream.h"
 
 #include "HorizonEngine/Events/Event.h"
 
@@ -26,21 +27,6 @@ namespace Hzn
 	};
 
 }
-
-template<>
-struct fmt::formatter<Hzn::Event> {
-	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
-		return ctx.end();
-	}
-	
-
-	template <typename FormatContext>
-	auto format(const Hzn::Event& input, FormatContext& ctx) -> decltype(ctx.out()) {
-		return format_to(ctx.out(),
-			"{}",
-			input.ToString());
-	}
-};
 
 #define HZN_CORE_TRACE(...)      ::Hzn::Logging::GetCoreLogger()->trace(__VA_ARGS__)
 #define HZN_CORE_INFO(...)       ::Hzn::Logging::GetCoreLogger()->info(__VA_ARGS__)

--- a/HorizonEngine/src/HorizonEngine/Logging/Logging.h
+++ b/HorizonEngine/src/HorizonEngine/Logging/Logging.h
@@ -7,6 +7,9 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/fmt/fmt.h"
+
+#include "HorizonEngine/Events/Event.h"
 
 namespace Hzn
 {
@@ -23,6 +26,21 @@ namespace Hzn
 	};
 
 }
+
+template<>
+struct fmt::formatter<Hzn::Event> {
+	constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+		return ctx.end();
+	}
+	
+
+	template <typename FormatContext>
+	auto format(const Hzn::Event& input, FormatContext& ctx) -> decltype(ctx.out()) {
+		return format_to(ctx.out(),
+			"{}",
+			input.ToString());
+	}
+};
 
 #define HZN_CORE_TRACE(...)      ::Hzn::Logging::GetCoreLogger()->trace(__VA_ARGS__)
 #define HZN_CORE_INFO(...)       ::Hzn::Logging::GetCoreLogger()->info(__VA_ARGS__)


### PR DESCRIPTION
added tvent type formattable to logging
fix spdlog cannot format an argument