### PR TITLE
Toolbar Menu for the User Interface 

### DIFF
--- a/HorizonEngine/src/HorizonEngine/ImGui/ImguiLayer.cpp
+++ b/HorizonEngine/src/HorizonEngine/ImGui/ImguiLayer.cpp
@@ -96,6 +96,6 @@ namespace Hzn
 		/*auto val = ImGui::GetCurrentContext();
 		std::cout << (val == nullptr) << std::endl;*/
 		static bool show = true;
-		ImGui::ShowDemoWindow(&show);
+		//ImGui::ShowDemoWindow(&show);
 	}
 }

--- a/HznApplication/HznApp.cpp
+++ b/HznApplication/HznApp.cpp
@@ -62,18 +62,13 @@ void EditorLayer::onAttach()
 
 void EditorLayer::onRenderImgui()
 {
-	// ImGuiStyle& style = ImGui::GetStyle();
-	// style.Colors[ImGuiCol_WindowBg] = ImVec4(255, 0, 0, 255); // RGB Values 
-
-	// static bool my_tool_active = true;
-	// ImGui::Begin("From Editor Layer", &my_tool_active, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
-	// ImGui::SetNextWindowSize(ImVec2(50,500));
-
 	ImVec2 vWindowSize = ImGui::GetMainViewport()->Size;
 	ImVec2 vPos0 = ImGui::GetMainViewport()->Pos;
 
 	ImGui::SetNextWindowPos(ImVec2((float)vPos0.x, (float)vPos0.y), ImGuiCond_Always);
 	ImGui::SetNextWindowSize(ImVec2((float)vWindowSize.x, (float)vWindowSize.y));
+
+	static bool my_tool_active = true;
 
 	if (ImGui::Begin(
 		"From Editor Layer",
@@ -97,19 +92,19 @@ void EditorLayer::onRenderImgui()
 			{
 				if (ImGui::BeginMenu("File"))
 				{
-					if (ImGui::MenuItem("Open")){ /* Do Something */ }
-					if (ImGui::MenuItem("Save")){ /* Do Something */ }
-					if (ImGui::MenuItem("Close")){ /* Do Something */ }
+					if (ImGui::MenuItem("Open", "Ctrl+O")) { /* Do Something */ }
+					if (ImGui::MenuItem("Save", "Ctrl+S")) { /* Do Something */ }
+					if (ImGui::MenuItem("Close", "Ctrl+W")) { my_tool_active = false; }
 					ImGui::EndMenu();
 				}
 				if (ImGui::BeginMenu("Edit"))
 				{
-					if(ImGui::MenuItem("Undo")){ /* Do Something */ }
-					if(ImGui::MenuItem("Redo")){ /* Do Something */ }
+					if(ImGui::MenuItem("Undo", "Ctrl+Z")) { /* Do Something */ }
+					if(ImGui::MenuItem("Redo", "Ctrl+Y")) { /* Do Something */ }
 
-					if(ImGui::MenuItem("Cut")){ /*Do Something*/ }
-					if (ImGui::MenuItem("Copy")) { /*Do Something*/ }
-					if (ImGui::MenuItem("Paste")) { /*Do Something*/ }
+					if(ImGui::MenuItem("Cut", "Ctrl+X")){ /*Do Something*/ }
+					if (ImGui::MenuItem("Copy", "Ctrl+C")) { /*Do Something*/ }
+					if (ImGui::MenuItem("Paste", "Ctrl+V")) { /*Do Something*/ }
 					ImGui::EndMenu();
 				}
 				if (ImGui::BeginMenu("Assets"))

--- a/HznApplication/HznApp.cpp
+++ b/HznApplication/HznApp.cpp
@@ -10,6 +10,8 @@ std::shared_ptr<Hzn::App> Hzn::createApp()
 	return std::make_shared<HznApp>();
 }
 
+// *********** SAMPLE LAYER **********
+
 SampleLayer::SampleLayer(const std::string& name) : Layer(name) {}
 
 void SampleLayer::onAttach()
@@ -38,6 +40,78 @@ void SampleLayer::onRenderImgui()
 void SampleLayer::onDetach() {}
 
 void SampleLayer::onEvent(Hzn::Event& event)
+{
+	if (event.GetTypeOfEvent() == Hzn::TypeOfEvent::KeyPressed)
+	{
+		Hzn::KeyPressedEvent& e = (Hzn::KeyPressedEvent&)event;
+		auto key = (char)e.GetKeyCode();
+		HZN_INFO("{0}", key);
+	}
+}
+
+// ********************
+
+// *********** EDITOR LAYER **********
+EditorLayer::EditorLayer(const std::string& name) : Layer(name) {}
+
+void EditorLayer::onAttach()
+{
+	HZN_INFO("Sample Layer Attached!");
+}
+
+void EditorLayer::onRenderImgui()
+{
+	static bool my_tool_active = true;
+	ImGui::Begin("From Editor Layer", &my_tool_active, ImGuiWindowFlags_MenuBar);
+	if (ImGui::BeginMenuBar())
+	{
+		if (ImGui::BeginMenu("File"))
+		{
+			if (ImGui::MenuItem("Open..", "Ctrl+O")) { /* Do stuff */ }
+			if (ImGui::MenuItem("Save", "Ctrl+S")) { /* Do stuff */ }
+			if (ImGui::MenuItem("Close", "Ctrl+W")) { my_tool_active = false; }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Edit"))
+		{
+			if (ImGui::MenuItem("Copy", "Ctrl+C")) { /* Do Stuff */ }
+			if (ImGui::MenuItem("Cut", "Ctrl+X")) { /* Do Stuff */ }
+			if (ImGui::MenuItem("Paste", "Ctrl+P")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Assets"))
+		{
+			if (ImGui::MenuItem("Asset Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Game Objects"))
+		{
+			if (ImGui::MenuItem("Game Objects Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Component"))
+		{
+			if (ImGui::MenuItem("Asset Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Window"))
+		{
+			if (ImGui::MenuItem("Window Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Help"))
+		{
+			if (ImGui::MenuItem("Help Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
+			ImGui::EndMenu();
+		}
+		ImGui::EndMenuBar();
+	}
+	ImGui::End();
+}
+
+void EditorLayer::onDetach() {}
+
+void EditorLayer::onEvent(Hzn::Event& event)
 {
 	if (event.GetTypeOfEvent() == Hzn::TypeOfEvent::KeyPressed)
 	{

--- a/HznApplication/HznApp.cpp
+++ b/HznApplication/HznApp.cpp
@@ -4,6 +4,7 @@
 #include "imgui_impl_opengl3.h"
 #include "HorizonEngine.h"
 #include "HznApp.h"
+#include "Window.h"
 
 std::shared_ptr<Hzn::App> Hzn::createApp()
 {
@@ -49,7 +50,7 @@ void SampleLayer::onEvent(Hzn::Event& event)
 	}
 }
 
-// ********************
+// ************************************************************************
 
 // *********** EDITOR LAYER **********
 EditorLayer::EditorLayer(const std::string& name) : Layer(name) {}
@@ -61,53 +62,88 @@ void EditorLayer::onAttach()
 
 void EditorLayer::onRenderImgui()
 {
-	static bool my_tool_active = true;
-	ImGui::Begin("From Editor Layer", &my_tool_active, ImGuiWindowFlags_MenuBar);
-	if (ImGui::BeginMenuBar())
+	// ImGuiStyle& style = ImGui::GetStyle();
+	// style.Colors[ImGuiCol_WindowBg] = ImVec4(255, 0, 0, 255); // RGB Values 
+
+	// static bool my_tool_active = true;
+	// ImGui::Begin("From Editor Layer", &my_tool_active, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
+	// ImGui::SetNextWindowSize(ImVec2(50,500));
+
+	ImVec2 vWindowSize = ImGui::GetMainViewport()->Size;
+	ImVec2 vPos0 = ImGui::GetMainViewport()->Pos;
+
+	ImGui::SetNextWindowPos(ImVec2((float)vPos0.x, (float)vPos0.y), ImGuiCond_Always);
+	ImGui::SetNextWindowSize(ImVec2((float)vWindowSize.x, (float)vWindowSize.y));
+
+	if (ImGui::Begin(
+		"From Editor Layer",
+		nullptr,
+		ImGuiWindowFlags_MenuBar |
+		ImGuiWindowFlags_NoResize |
+		ImGuiWindowFlags_NoMove |
+		ImGuiWindowFlags_NoCollapse |
+		ImGuiWindowFlags_NoBringToFrontOnFocus |
+		ImGuiWindowFlags_NoTitleBar
+	)
+		)
+
 	{
-		if (ImGui::BeginMenu("File"))
 		{
-			if (ImGui::MenuItem("Open..", "Ctrl+O")) { /* Do stuff */ }
-			if (ImGui::MenuItem("Save", "Ctrl+S")) { /* Do stuff */ }
-			if (ImGui::MenuItem("Close", "Ctrl+W")) { my_tool_active = false; }
-			ImGui::EndMenu();
+			static const ImGuiDockNodeFlags dockspaceFlags = ImGuiDockNodeFlags_None;
+			ImGuiID dockSpace = ImGui::GetID("MainWindowDockspace");
+			ImGui::DockSpace(dockSpace, ImVec2(0.0f, 0.0f), dockspaceFlags);
+
+			if (ImGui::BeginMainMenuBar())
+			{
+				if (ImGui::BeginMenu("File"))
+				{
+					if (ImGui::MenuItem("Open")){ /* Do Something */ }
+					if (ImGui::MenuItem("Save")){ /* Do Something */ }
+					if (ImGui::MenuItem("Close")){ /* Do Something */ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::BeginMenu("Edit"))
+				{
+					if(ImGui::MenuItem("Undo")){ /* Do Something */ }
+					if(ImGui::MenuItem("Redo")){ /* Do Something */ }
+
+					if(ImGui::MenuItem("Cut")){ /*Do Something*/ }
+					if (ImGui::MenuItem("Copy")) { /*Do Something*/ }
+					if (ImGui::MenuItem("Paste")) { /*Do Something*/ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::BeginMenu("Assets"))
+				{
+					if(ImGui::MenuItem("Asset Submenu_1")){ /* Do Something */ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::BeginMenu("Game Objects"))
+				{
+					if (ImGui::MenuItem("Game Object Submenu_1")) { /* Do Something */ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::BeginMenu("Components"))
+				{
+					if (ImGui::MenuItem("Components Submenu_1")) { /* Do Something */ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::MenuItem("Window"))
+				{
+					if (ImGui::MenuItem("Window Submenu_1")) { /* Do Something */ }
+					ImGui::EndMenu();
+				}
+				if (ImGui::BeginMenu("Help"))
+				{
+					if (ImGui::MenuItem("Help Submenu_1")) { /* Do Something */ }
+					ImGui::EndMenu();
+				}
+			}
+			ImGui::EndMainMenuBar();
 		}
-		if (ImGui::BeginMenu("Edit"))
-		{
-			if (ImGui::MenuItem("Copy", "Ctrl+C")) { /* Do Stuff */ }
-			if (ImGui::MenuItem("Cut", "Ctrl+X")) { /* Do Stuff */ }
-			if (ImGui::MenuItem("Paste", "Ctrl+P")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		if (ImGui::BeginMenu("Assets"))
-		{
-			if (ImGui::MenuItem("Asset Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		if (ImGui::BeginMenu("Game Objects"))
-		{
-			if (ImGui::MenuItem("Game Objects Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		if (ImGui::BeginMenu("Component"))
-		{
-			if (ImGui::MenuItem("Asset Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		if (ImGui::BeginMenu("Window"))
-		{
-			if (ImGui::MenuItem("Window Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		if (ImGui::BeginMenu("Help"))
-		{
-			if (ImGui::MenuItem("Help Sub Menu 1", "Ctrl+A")) { /* Do Stuff */ }
-			ImGui::EndMenu();
-		}
-		ImGui::EndMenuBar();
 	}
 	ImGui::End();
 }
+
 
 void EditorLayer::onDetach() {}
 

--- a/HznApplication/HznApp.cpp
+++ b/HznApplication/HznApp.cpp
@@ -127,7 +127,7 @@ void EditorLayer::onRenderImgui()
 					if (ImGui::MenuItem("Components Submenu_1")) { /* Do Something */ }
 					ImGui::EndMenu();
 				}
-				if (ImGui::MenuItem("Window"))
+				if (ImGui::BeginMenu("Window"))
 				{
 					if (ImGui::MenuItem("Window Submenu_1")) { /* Do Something */ }
 					ImGui::EndMenu();

--- a/HznApplication/HznApp.h
+++ b/HznApplication/HznApp.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// ********** Sample Layer **********
+
 class SampleLayer : public Hzn::Layer 
 {
 public:
@@ -16,12 +18,30 @@ public:
 
 };
 
+// ********** Edior Layer **********
+
+class EditorLayer : public Hzn::Layer
+{
+public:
+	EditorLayer(const std::string& name = "Editor Layer");
+
+	virtual void onAttach() override;
+
+	virtual void onDetach() override;
+
+	virtual void onRenderImgui() override;
+
+	virtual void onEvent(Hzn::Event& event) override;
+};
+
+
 class HznApp : public Hzn::App
 {
 public:
 	HznApp() 
 	{
-		addLayer(new SampleLayer());
+		// addLayer(new SampleLayer());
+		addLayer(new EditorLayer());
 	}
 	~HznApp() {}
 };


### PR DESCRIPTION
- Created a toolbar menu that docs to the top of the screen using Dear ImGui. 
- Menu includes keyboard shortcuts for the common toolbar menu items (copy, paste, open etc....)
- Changes to the styling may be necessary.
- Included placeholder menu and sub-menu items based on typical game engine menus (Game Objects, Assets, Components). These may be changed in the future depending on the needs of the game engine UI. 